### PR TITLE
Add an adaptive zoom factor

### DIFF
--- a/PockIt/qml/ui/ArticleViewPage.qml
+++ b/PockIt/qml/ui/ArticleViewPage.qml
@@ -634,6 +634,7 @@ Page {
                 Qt.openUrlExternally(request.url);
             }
         }
+        zoomFactor: units.gu(1) / 8.4
         profile:  WebEngineProfile{
             httpUserAgent: "Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"
         }


### PR DESCRIPTION
On most devices, the WebEngineView's scaling factor has to be adjusted to fit the screen's DPI. Without it, the content would appear too small on a real device. This pull request solves this.

Have a fantastic day. :)